### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -3,6 +3,9 @@ name: Run tests and upload coverage
 on:
   push
 
+permissions:
+  contents: read
+
 jobs:
     test:
       name: Run tests and collect coverage


### PR DESCRIPTION
Potential fix for [https://github.com/bachnxuan/gki_kernel_builder/security/code-scanning/1](https://github.com/bachnxuan/gki_kernel_builder/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's actions, it primarily reads repository contents and uploads coverage results. Therefore, the `contents: read` permission is sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `test` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
